### PR TITLE
Habilitar Github Workflow

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,0 +1,44 @@
+name: Laravel
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, pdo, sqlite
+          coverage: none
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Directory permissions
+        run: chmod -R 777 storage bootstrap/cache
+
+      - name: Create SQLite database
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+
+      - name: Run tests
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/database.sqlite
+        run: php artisan test

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/domingoruiz/asoges"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "filament/filament": "^4.0",
         "laravel/framework": "^12.0",
         "maatwebsite/excel": "^3.1"

--- a/tests/Feature/LibroProyectoTest.php
+++ b/tests/Feature/LibroProyectoTest.php
@@ -14,7 +14,7 @@ class LibroProyectoTest extends TestCase
         $aso = Aso::create(['nombre' => 'Asociación Proyecto Test', 'cif' => 'A00000009', 'domicilio_social' => 'Dirección Test', 'fch_constitucion' => now(), 'alt_usr' => 1]);
 
         // Crea un proyecto
-        $proyecto = LibroProyecto::create(['aso_id' => $aso->id, 'nombre' => 'Proyecto de Innovación', 'estado' => 'Pendiente', 'fecha_inicio' => now()->toDateString(), 'fecha_fin' => now()->addMonths(6)->toDateString(), 'observaciones' => 'Proyecto de prueba en el libro de proyectos.', 'alt_usr' => 1]);
+        $proyecto = LibroProyecto::create(['aso_id' => $aso->id, 'nombre' => 'Proyecto de Innovación', 'estado' => 'pendiente', 'fecha_inicio' => now()->toDateString(), 'fecha_fin' => now()->addMonths(6)->toDateString(), 'observaciones' => 'Proyecto de prueba en el libro de proyectos.', 'alt_usr' => 1]);
         $this->assertDatabaseHas('libro_proyectos', [
             'aso_id' => $aso->id,
             'nombre' => 'Proyecto de Innovación',


### PR DESCRIPTION
**Descripción**
Se añade un workflow de GitHub Actions que ejecuta los tests de Laravel automáticamente en cada push y pull request a la rama main.

**Cambios realizados**
- Se crea workflow Laravel en GitHub Actions.
- Se configura PHP 8.4 con extensiones necesarias.
- Se instalan dependencias del proyecto.
- Se prepara el entorno Laravel para testing.
- Se ejecutan los tests usando base de datos SQLite.

**Resultado**
- CI automatizado funcionando correctamente.
- Validación continua del código antes de mergear a main.